### PR TITLE
http4s: 1.0.0-M42 -> 1.0.0-M43

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,11 @@ lazy val root = project
 lazy val l4_runners = project
   .in(file("modules/l4-runners"))
   .settings(
-    libraryDependencies += "org.http4s" %% "http4s-ember-client" % "1.0.0-M42",
-    libraryDependencies += "org.http4s" %% "http4s-ember-server" % "1.0.0-M42",
-    libraryDependencies += "org.http4s" %% "http4s-dsl" % "1.0.0-M42",
+    libraryDependencies += "org.http4s" %% "http4s-ember-client" % "1.0.0-M43",
+    libraryDependencies += "org.http4s" %% "http4s-ember-server" % "1.0.0-M43",
+    libraryDependencies += "org.http4s" %% "http4s-dsl" % "1.0.0-M43",
     libraryDependencies += "org.typelevel" %% "log4cats-slf4j" % "2.7.0",
-    libraryDependencies += "org.http4s" %% "http4s-circe" % "1.0.0-M42"
+    libraryDependencies += "org.http4s" %% "http4s-circe" % "1.0.0-M43"
   )
   .dependsOn(l3_drivers, l2_use_cases, l1_domain)
 


### PR DESCRIPTION
📦 Updates 
* [org.http4s:http4s-circe](https://github.com/http4s/http4s)
* [org.http4s:http4s-dsl](https://github.com/http4s/http4s)
* [org.http4s:http4s-ember-client](https://github.com/http4s/http4s)
* [org.http4s:http4s-ember-server](https://github.com/http4s/http4s)

 from `1.0.0-M42` to `1.0.0-M43`

📜 [GitHub Release Notes](https://github.com/http4s/http4s/releases/tag/v1.0.0-M43) - [Version Diff](https://github.com/http4s/http4s/compare/v1.0.0-M42...v1.0.0-M43)