### PR TITLE
cats-effect: 3.5.4 -> 3.5.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val l3_drivers = project
 lazy val l2_use_cases = project
   .in(file("modules/l2-use-cases"))
   .settings(
-    libraryDependencies += "org.typelevel" %% "cats-effect" % "3.5.4"
+    libraryDependencies += "org.typelevel" %% "cats-effect" % "3.5.5"
   )
   .dependsOn(l1_domain)
 


### PR DESCRIPTION
📦 Updates [org.typelevel:cats-effect](https://github.com/typelevel/cats-effect) from `3.5.4` to `3.5.5`

📜 [GitHub Release Notes](https://github.com/typelevel/cats-effect/releases/tag/v3.5.5) - [Version Diff](https://github.com/typelevel/cats-effect/compare/v3.5.4...v3.5.5)